### PR TITLE
Resolve access denied for missing process privilege

### DIFF
--- a/lib/scalingo_databases_rake_tasks/tasks/mysql.rake
+++ b/lib/scalingo_databases_rake_tasks/tasks/mysql.rake
@@ -47,7 +47,7 @@ namespace :scalingo do
       end
 
       def self.backup database, user, password, host, port
-        base_cmd = "/usr/bin/env mysqldump --add-drop-table --create-options --disable-keys --extended-insert --single-transaction --quick --set-charset -h #{host} -P #{port} -u #{user}"
+        base_cmd = "/usr/bin/env mysqldump --no-tablespaces --add-drop-table --create-options --disable-keys --extended-insert --single-transaction --quick --set-charset -h #{host} -P #{port} -u #{user}"
         cmd = ""
         cmd << base_cmd
         public_cmd = ""

--- a/lib/scalingo_databases_rake_tasks/tasks/mysql.rake
+++ b/lib/scalingo_databases_rake_tasks/tasks/mysql.rake
@@ -36,7 +36,7 @@ namespace :scalingo do
       DUMP_PATH = Dir.tmpdir + "/#{DUMP_NAME}"
 
       def self.local_credentials
-        config = ActiveRecord::Base.configurations[Rails.env]
+        config= Rails.application.config_for(:database, env: Rails.env)
         return [
           config['database'],
           config['username'],


### PR DESCRIPTION
Resolve this errors/warning:
- mysqldump: Error: 'Access denied; you need (at least one of) the PROCESS privilege(s) for this operation' when trying to dump tablespaces. 
Putting --no-tablespaces mysqldump flag until the user has PROCESS priviledge (couldn't grant it for user)